### PR TITLE
theme option sets to and reads from LocalStorage

### DIFF
--- a/src/App.js
+++ b/src/App.js
@@ -1,5 +1,5 @@
 // import "./css/App.css";
-import React, { useState } from 'react'
+import React, { useState, useEffect } from 'react'
 import { useRecoilState } from 'recoil'
 import { testState } from './store/atom'
 import { ThemeProvider } from 'styled-components'
@@ -13,8 +13,16 @@ import lightTheme from './theme/lightTheme'
 const App = () => {
   const [isDarkTheme, setIsDarkTheme] = useState(false)
 
+  useEffect(() => {
+    const localTheme = localStorage.getItem('localTheme')
+    localTheme === 'dark' ? setIsDarkTheme(true) : setIsDarkTheme(false)
+  }, [])
+
   const toggleTheme = () => {
     setIsDarkTheme(!isDarkTheme)
+    const localThemeVal =
+      localStorage.getItem('localTheme') === 'dark' ? 'light' : 'dark'
+    localStorage.setItem('localTheme', localThemeVal)
   }
 
   const [test, setTest] = useRecoilState(testState)

--- a/src/components/SearchBox/StyledSearchBox.js
+++ b/src/components/SearchBox/StyledSearchBox.js
@@ -10,6 +10,10 @@ const StyledSearchBox = styled.form`
   /* border: 1px solid black; */
   /* box-sizing: border-box; */
   input {
+    ::placeholder {
+      color: ${(props) => props.theme.color.accent};
+    }
+    background-color: ${(props) => props.theme.color.secondaryBackground};
     outline: none;
     width: min(400px, 90vw);
     padding: 8px;

--- a/src/theme/darkTheme.js
+++ b/src/theme/darkTheme.js
@@ -2,11 +2,14 @@ import theme from './index'
 
 const darkTheme = {
   ...theme,
+  // None of these are set colors
   color: {
     background: 'black',
-    primaryColor: '#FF6347',
-    secondaryColor: 'yellow',
-    tertiaryColor: 'blue'
+    secondaryBackground: '#bfbfbf',
+    primary: '#FF6347',
+    secondary: 'yellow',
+    tertiary: 'blue',
+    accent: 'blue'
   }
 }
 

--- a/src/theme/lightTheme.js
+++ b/src/theme/lightTheme.js
@@ -2,11 +2,14 @@ import theme from './index'
 
 const lightTheme = {
   ...theme,
-  color:{
+  // None of these are set colors
+  color: {
     background: 'white',
-    primaryColor: '#FF6347',
-    secondaryColor: 'brown',
-    tertiaryColor: 'red'
+    secondaryBackground: '#eee',
+    primary: '#FF6347',
+    secondary: 'brown',
+    tertiary: 'red',
+    accent: 'green'
   }
 }
 


### PR DESCRIPTION
# Description

Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. List any dependencies that are required for this change.

Fixes # (issue)

## Type of change

Please delete options that are not relevant.

- [x] New feature (non-breaking change which adds functionality)

# How Has This Been Tested?

Tested manual on local. Refreshed browser and theme stuck.
Reran npm start to check both light and dark mode were read off of local storage on first render.
All worked as expected

# Checklist:

- [x ] My code follows the style guidelines of this project
- [ x] I have performed a self-review of my own code
- [ x] I have commented my code, particularly in hard-to-understand areas
- [ x] I have made corresponding changes to the documentation
- [ x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x ] New and existing unit tests pass locally with my changes
- [ x] Any dependent changes have been merged and published in downstream modules
